### PR TITLE
point download link to wordpressorg trunk

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 			A beautiful WordPress events calendar with customizable views, coloring, filtering, date formats, and
 			images. Fully optimized for mobile.
 		</p>
-		<a href="https://my.eventespresso.com/wp-content/uploads/2025/03/events-calendar-plus.zip"
+		<a href="https://downloads.wordpress.org/plugin/events-calendar-plus.zip"
 		   class="download-button"
 		>Download Calendar+ for WordPress
 		</a>
@@ -172,7 +172,7 @@
 	</ul>
 </section>
 <footer class="container">
-	<a href="https://my.eventespresso.com/wp-content/uploads/2025/03/events-calendar-plus.zip"
+	<a href="https://downloads.wordpress.org/plugin/events-calendar-plus.zip"
 	   class="download-button"
 	>Download Calendar+ for WordPress
 	</a>


### PR DESCRIPTION
plus some typos and image fixes.

Download link (https://downloads.wordpress.org/plugin/events-calendar-plus.zip)